### PR TITLE
Make internal Redis instance Accessible

### DIFF
--- a/libs/redis/store/redis.ts
+++ b/libs/redis/store/redis.ts
@@ -39,7 +39,7 @@ export class RedisStoreConnectError extends Error {
 
 /** A RedisStore that is backed by a Redis instance. */
 export class RedisStore implements Store {
-  constructor(private readonly redis: RedisInstance) {}
+  constructor(public readonly redis: RedisInstance) {}
   public async del(key: string): Promise<void> {
     await this.redis.del(key)
   }


### PR DESCRIPTION
This PR makes the internal Redis instance used by a `RedisStore` publicly accessible to allow for advanced custom interactions not covered by the type-safe interfaces provided by `RedisStore`.