### PR TITLE
Authorization Pipeline on RestService

### DIFF
--- a/example/context/index.ts
+++ b/example/context/index.ts
@@ -1,0 +1,28 @@
+import { RestService, Host } from '@sidewinder/server'
+
+export class ActionService extends RestService {
+  public onAction = this.post('/echo', async (req, res) => {
+    console.log('claims', req.context.get('claims'))
+    const buffer = await req.arrayBuffer()
+    await res.arrayBuffer(buffer)
+  })
+  public onAuthorize = this.event('authorize', (context, request) => {
+    request.context.set('claims', { a: 1, b: 2 })
+  })
+}
+
+const host = new Host()
+host.use('/action', new ActionService())
+host.listen(5000)
+
+async function start() {
+  const method = 'post'
+  const headers = { authorization: 'Bearer 12345' }
+  const body = new Uint8Array(1000)
+  const result = await fetch('http://localhost:5000/action/echo', { method, headers, body })
+    .then((res) => res.text())
+    .catch(console.log)
+  console.log(result)
+}
+
+start()

--- a/hammer.mjs
+++ b/hammer.mjs
@@ -4,7 +4,7 @@ import { compilePackage, packPackage } from './build/index'
 // Packages
 // -------------------------------------------------------------
 
-const version = '0.12.8'
+const version = '0.12.9'
 const packages = [
     ['async',     version, 'Sidewinder Async'],
     ['buffer',    version, 'Sidewinder Buffer'],

--- a/libs/server/rest/request.ts
+++ b/libs/server/rest/request.ts
@@ -33,23 +33,21 @@ import { IncomingMessage } from 'http'
 
 export class RestRequest {
   readonly #ipAddress: string
-  readonly #context: Map<string, string>
+  readonly #context: Map<string, unknown>
   readonly #headers: Map<string, string>
   readonly #query: Map<string, string>
   readonly #params: Map<string, string>
 
   constructor(private readonly request: IncomingMessage, params: Record<string, string>, public readonly clientId: string) {
     this.#ipAddress = this.#readIpAddress(request)
-    this.#context = new Map<string, string>()
+    this.#context = new Map<string, unknown>()
     this.#headers = this.#readHeaders(request)
     this.#query = this.#readQuery(request)
     this.#params = this.#readParams(params)
   }
-
   // ------------------------------------------------------------------------------
   // Publics
   // ------------------------------------------------------------------------------
-
   /**
    * Gets the ip address associated with this request. This address will either
    * be the raw socket remoteAddress, or in the instance of a load balancer, the
@@ -59,8 +57,8 @@ export class RestRequest {
   public get ipAddress(): string {
     return this.#ipAddress
   }
-  /** Gets request context variables */
-  public get context(): Map<string, string> {
+  /** Gets or sets request context variables */
+  public get context(): Map<string, unknown> {
     return this.#context
   }
   /** Gets the http headers for this request */


### PR DESCRIPTION
This PR implements an authorization event for the `RestService`. If subscribed to, the service will pass the `clientId` (connection context) and `RestRequest` for verification. Claims gathered during an authorization process can be written to the request's `req.context` Map which will be passed along to a downstream handler. Like the Rpc services, the implementation of authorization handlers should `throw` which will return 401 unauthorized to the caller.

CC @waikikamoukow 