### PR TITLE
Redis Constructor Overloads for Cluster

### DIFF
--- a/hammer.mjs
+++ b/hammer.mjs
@@ -4,7 +4,7 @@ import { compilePackage, packPackage } from './build/index'
 // Packages
 // -------------------------------------------------------------
 
-const version = '0.12.9'
+const version = '0.12.10'
 const packages = [
     ['async',     version, 'Sidewinder Async'],
     ['buffer',    version, 'Sidewinder Buffer'],

--- a/libs/redis/channel/redis/receiver.ts
+++ b/libs/redis/channel/redis/receiver.ts
@@ -28,7 +28,7 @@ THE SOFTWARE.
 
 import { Static, TSchema } from '@sidewinder/type'
 import { Receiver } from '@sidewinder/channel'
-import { Redis, RedisOptions } from 'ioredis'
+import { Cluster, Redis, RedisOptions } from 'ioredis'
 import { RedisDecoder } from '../../codecs/index'
 import { RedisConnect } from '../../connect'
 
@@ -36,7 +36,7 @@ import { RedisConnect } from '../../connect'
 export class RedisReceiver<T extends TSchema> implements Receiver<Static<T>> {
   readonly #decoder: RedisDecoder<T>
   #closed: boolean
-  constructor(private readonly schema: T, private readonly channel: string, private readonly redis: Redis) {
+  constructor(private readonly schema: T, private readonly channel: string, private readonly redis: Cluster | Redis) {
     this.#decoder = new RedisDecoder<T>(this.schema)
     this.#closed = false
   }

--- a/libs/redis/channel/redis/sender.ts
+++ b/libs/redis/channel/redis/sender.ts
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import { Redis, RedisOptions } from 'ioredis'
+import { Cluster, Redis, RedisOptions } from 'ioredis'
 import { Static, TSchema } from '@sidewinder/type'
 import { SyncSender } from '@sidewinder/channel'
 import { RedisEncoder } from '../../codecs/index'
@@ -42,7 +42,7 @@ export class RedisSenderError extends Error {
 export class RedisSender<T extends TSchema> implements SyncSender<Static<T>> {
   readonly #encoder: RedisEncoder<T>
   #closed: boolean
-  constructor(private readonly schema: T, private readonly channel: string, private readonly redis: Redis) {
+  constructor(private readonly schema: T, private readonly channel: string, private readonly redis: Cluster | Redis) {
     this.#encoder = new RedisEncoder(this.schema)
     this.#closed = false
   }

--- a/libs/redis/pubsub/redis/receiver.ts
+++ b/libs/redis/pubsub/redis/receiver.ts
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import { Redis, RedisOptions } from 'ioredis'
+import { Cluster, Redis, RedisOptions } from 'ioredis'
 import { Static, TSchema } from '@sidewinder/type'
 import { Channel, Receiver } from '@sidewinder/channel'
 import { RedisDecoder } from '../../codecs/index'
@@ -37,7 +37,7 @@ export class PubSubRedisReceiver<T extends TSchema> implements Receiver<Static<T
   readonly #decoder: RedisDecoder<T>
   readonly #channel: Channel<unknown>
 
-  constructor(private readonly schema: T, public readonly channel: string, private readonly redis: Redis) {
+  constructor(private readonly schema: T, public readonly channel: string, private readonly redis: Cluster | Redis) {
     this.#decoder = new RedisDecoder(this.schema)
     this.#channel = new Channel<unknown>()
     this.redis.subscribe(this.#encodeKey())

--- a/libs/redis/pubsub/redis/sender.ts
+++ b/libs/redis/pubsub/redis/sender.ts
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import { Redis, RedisOptions } from 'ioredis'
+import { Cluster, Redis, RedisOptions } from 'ioredis'
 import { SyncSender } from '@sidewinder/channel'
 import { Static, TSchema } from '@sidewinder/type'
 import { RedisEncoder } from '../../codecs/index'
@@ -37,7 +37,7 @@ export class PubSubRedisSender<T extends TSchema> implements SyncSender<Static<T
   readonly #encoder: RedisEncoder<T>
   #ended: boolean
 
-  constructor(private readonly schema: T, private readonly channel: string, private readonly redis: Redis) {
+  constructor(private readonly schema: T, private readonly channel: string, private readonly redis: Cluster | Redis) {
     this.#encoder = new RedisEncoder(this.schema)
     this.#ended = false
   }

--- a/libs/redis/store/redis.ts
+++ b/libs/redis/store/redis.ts
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import IORedis, { RedisOptions, Redis as RedisInstance } from 'ioredis'
+import IORedis, { RedisOptions, Redis as RedisInstance, Cluster as ClusterInstance } from 'ioredis'
 import { Timeout } from '@sidewinder/async'
 import { SetOptions, Store } from './store'
 export { RedisOptions } from 'ioredis'
@@ -39,7 +39,7 @@ export class RedisStoreConnectError extends Error {
 
 /** A RedisStore that is backed by a Redis instance. */
 export class RedisStore implements Store {
-  constructor(public readonly redis: RedisInstance) {}
+  constructor(public readonly redis: RedisInstance | ClusterInstance) {}
   public async del(key: string): Promise<void> {
     await this.redis.del(key)
   }


### PR DESCRIPTION
This PR updates the Redis constructors to accept a Cluster instance as well as a Redis instance. No functional changes.